### PR TITLE
Allow container perms to interact with item frames.

### DIFF
--- a/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/GriefPrevention.java
@@ -589,6 +589,7 @@ public class GriefPrevention extends JavaPlugin
         this.config_claims_supplyPlayerManual = config.getBoolean("GriefPrevention.Claims.DeliverManuals", true);
         this.config_claims_manualDeliveryDelaySeconds = config.getInt("GriefPrevention.Claims.ManualDeliveryDelaySeconds", 30);
         this.config_claims_ravagersBreakBlocks = config.getBoolean("GriefPrevention.Claims.RavagersBreakBlocks", true);
+        this.config_claims_containerTrustForItemFrames = config.getBoolean("GriefPrevention.Claims.ContainerTrustForItemFrames", true);
 
         this.config_claims_firespreads = config.getBoolean("GriefPrevention.Claims.FireSpreadsInClaims", false);
         this.config_claims_firedamages = config.getBoolean("GriefPrevention.Claims.FireDamagesInClaims", false);
@@ -843,6 +844,7 @@ public class GriefPrevention extends JavaPlugin
         outConfig.set("GriefPrevention.Claims.DeliverManuals", config_claims_supplyPlayerManual);
         outConfig.set("GriefPrevention.Claims.ManualDeliveryDelaySeconds", config_claims_manualDeliveryDelaySeconds);
         outConfig.set("GriefPrevention.Claims.RavagersBreakBlocks", config_claims_ravagersBreakBlocks);
+        outConfig.set("GriefPrevention.Claims.ContainerTrustForItemFrames", config_claims_containerTrustForItemFrames);
 
         outConfig.set("GriefPrevention.Claims.FireSpreadsInClaims", config_claims_firespreads);
         outConfig.set("GriefPrevention.Claims.FireDamagesInClaims", config_claims_firedamages);

--- a/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
+++ b/src/main/java/me/ryanhamshire/GriefPrevention/PlayerEventHandler.java
@@ -1200,8 +1200,24 @@ class PlayerEventHandler implements Listener
         }
         
         //don't allow interaction with item frames or armor stands in claimed areas without build permission
+        // (or container permission instead, if configured that way)
 		if(entity.getType() == EntityType.ARMOR_STAND || entity instanceof Hanging)
 		{
+                    if (instance.config_claims_containerTrustForItemFrames)
+                    {
+                        // Config says only container permission required to
+                        // interact, check for that
+                        Claim claim = this.dataStore.getClaimAt(entity.getLocation(), false, playerData.lastClaim);
+                        String noContainersReason = claim.allowContainers(player);
+                        if(noContainersReason != null)
+                        {
+                            instance.sendMessage(player, TextMode.Err, noContainersReason);
+                            event.setCancelled(true);
+                            return;
+                        }
+
+                    } else {
+                        // Require build permission at this location
 			String noBuildReason = instance.allowBuild(player, entity.getLocation(), Material.ITEM_FRAME); 
 			if(noBuildReason != null)
 			{
@@ -1209,6 +1225,8 @@ class PlayerEventHandler implements Listener
 				event.setCancelled(true);
 				return;
 			}			
+                    }
+
 		}
 		
 		//limit armor placements when entity count is too high


### PR DESCRIPTION
New config option Claims.ContainerTrustForItemFrames to change the
permission required to interact with item frames from build permissions
(which would let the player also break the frame / destroy the rest of
the claim) to containertrust.

Raised as a PR to master on my fork currently just for discussion, if the feature is accepted I'll get this fork back in line with the upstream then PR to there, but it's not yet tested, just raised to discuss.